### PR TITLE
Set tini subreaper environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN bundle config set --without 'development test' \
 # Production
 FROM ruby:3.1.2-alpine as production
 
+ENV TINI_SUBREAPER=true
+
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache tini \


### PR DESCRIPTION
From fly.io

```
 2022-12-28T22:40:43.991 app[0783ae25] dfw [info] [WARN tini (523)] Tini is not running as PID 1 and isn't registered as a child subreaper.

2022-12-28T22:40:43.991 app[0783ae25] dfw [info] Zombie processes will not be re-parented to Tini, so zombie reaping won't work.

2022-12-28T22:40:43.991 app[0783ae25] dfw [info] To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1. 
```