### PR TITLE
Deploy to flyctl without release step

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,41 +1,36 @@
-# fly.toml file generated for grape-api-boilerplate on 2022-09-15T08:43:59-06:00
+# fly.toml app configuration file generated for grape-api-boilerplate on 2023-08-10T11:41:10-06:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
 app = "grape-api-boilerplate"
 kill_signal = "SIGINT"
-kill_timeout = 5
-processes = []
-
-[env]
+kill_timeout = "5s"
+[processes]
+  app = "/bin/sh -c 'bundle exec rake db:migrate && tini -- bundle exec puma -C config/puma/puma.rb'"
 
 [experimental]
-  allowed_public_ports = []
   auto_rollback = true
 
-[deploy]
-  release_command = "bundle exec rake db:migrate"
-
 [[services]]
-  http_checks = []
+  protocol = "tcp"
   internal_port = 3000
   processes = ["app"]
-  protocol = "tcp"
-  script_checks = []
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
   [services.concurrency]
+    type = "connections"
     hard_limit = 25
     soft_limit = 20
-    type = "connections"
-
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
 
   [[services.tcp_checks]]
-    grace_period = "1s"
     interval = "15s"
-    restart_limit = 0
     timeout = "2s"
+    grace_period = "1s"


### PR DESCRIPTION
Just jam the release step in the same machine since I don't want to add a credit card.

```Running grape-api-boilerplate release_command: bundle exec rake db:migrate
Error: release command failed - aborting deployment. error running release_command machine: error creating a release_command machine: failed to launch VM: To create more than 1 machine per app please add a payment method. https://fly.io/dashboard/tech-av56unbr4tynjg3-duffy-sh/billing```